### PR TITLE
feat: Implement enhanced link intellisense plugin

### DIFF
--- a/EnhancedLinkSuggester.ts
+++ b/EnhancedLinkSuggester.ts
@@ -1,0 +1,260 @@
+import {
+    App,
+    Editor,
+    EditorPosition,
+    EditorSuggest,
+    EditorSuggestContext,
+    EditorSuggestTriggerInfo,
+    TFile,
+    fuzzySearch, // Ensure this is imported
+    FrontMatterCache,
+    HeadingCache,
+    BlockCache,
+} from 'obsidian';
+import { debounced } from './utils';
+
+interface MySuggestion {
+    type: 'note' | 'alias' | 'heading' | 'block' | 'content';
+    displayText: string;
+    insertText: string;
+    filePath: string;
+    score: number;
+    isRecent?: boolean;
+}
+
+export class EnhancedLinkSuggester extends EditorSuggest<MySuggestion> {
+    private debouncedGetSuggestions: (context: EditorSuggestContext) => Promise<MySuggestion[]>;
+    private recentFiles: TFile[] = [];
+    private readonly MAX_RECENT_FILES = 20;
+    private omnisearchApi: typeof window.omnisearch;
+
+    constructor(app: App, omnisearchApi: typeof window.omnisearch) {
+        super(app);
+        this.omnisearchApi = omnisearchApi;
+        this.debouncedGetSuggestions = debounced(this._getSuggestions.bind(this), 300);
+        this.updateRecentFiles();
+        this.app.workspace.on('file-open', () => this.updateRecentFiles()); // Bind 'this' context correctly
+    }
+
+    private updateRecentFiles(): void {
+        const recentFilePaths = this.app.workspace.getLastOpenFiles().slice(0, this.MAX_RECENT_FILES);
+        this.recentFiles = recentFilePaths
+            .map(path => this.app.vault.getFileByPath(path))
+            .filter((file): file is TFile => file instanceof TFile);
+    }
+
+    onTrigger(cursor: EditorPosition, editor: Editor, file: TFile | null): EditorSuggestTriggerInfo | null {
+        const line = editor.getLine(cursor.line);
+        const match = line.substring(0, cursor.ch).match(/\[\[([^\]]*)$/);
+        if (match) {
+            return {
+                start: { line: cursor.line, ch: match.index! + 2 },
+                end: cursor,
+                query: match[1],
+            };
+        }
+        return null;
+    }
+
+    async getSuggestions(context: EditorSuggestContext): Promise<MySuggestion[]> {
+        // Store context for use in _getSuggestions if needed for editor operations
+        // this.context is already available in EditorSuggest
+        return this.debouncedGetSuggestions(context);
+    }
+
+    private async _getSuggestions(context: EditorSuggestContext): Promise<MySuggestion[]> {
+        const query = context.query.toLowerCase();
+        const uniqueSuggestions = new Map<string, MySuggestion>();
+        let recentMatches: MySuggestion[] = [];
+
+        // --- Stage 1: Recent Files (from previous step, ensure it's complete) ---
+        for (const file of this.recentFiles) {
+            const cache = this.app.metadataCache.getFileCache(file);
+            if (!cache) continue;
+
+            const titleMatchResult = query === '' ? null : fuzzySearch(query, file.basename.toLowerCase());
+            if (query === '' || titleMatchResult) {
+                recentMatches.push({
+                    type: 'note',
+                    displayText: file.basename,
+                    insertText: file.basename,
+                    filePath: file.path,
+                    score: query === '' ? 10000 : (titleMatchResult?.score || 0) + (query === file.basename.toLowerCase() ? 1000 : 0), // Boost exact recent title
+                    isRecent: true,
+                });
+            }
+
+            if (query !== '') {
+                const frontmatter = cache.frontmatter as FrontMatterCache;
+                if (frontmatter && frontmatter.aliases) {
+                    for (const alias of frontmatter.aliases) {
+                        if (typeof alias === 'string') {
+                            const aliasMatchResult = fuzzySearch(query, alias.toLowerCase());
+                            if (aliasMatchResult) {
+                                recentMatches.push({
+                                    type: 'alias',
+                                    displayText: alias,
+                                    insertText: `${file.basename}|${alias}`,
+                                    filePath: file.path,
+                                    score: aliasMatchResult.score + (query === alias.toLowerCase() ? 500 : 0), // Boost exact alias
+                                    isRecent: true,
+                                });
+                            }
+                        }
+                    }
+                }
+
+                if (cache.headings) {
+                    for (const heading of cache.headings) {
+                        const headingMatchResult = fuzzySearch(query, heading.heading.toLowerCase());
+                        if (headingMatchResult) {
+                            recentMatches.push({
+                                type: 'heading',
+                                displayText: heading.heading,
+                                insertText: `${file.basename}#${heading.heading}`,
+                                filePath: file.path,
+                                score: headingMatchResult.score,
+                                isRecent: true,
+                            });
+                        }
+                    }
+                }
+
+                if (cache.blocks && this.context?.editor) { // Ensure editor context is available
+                    for (const blockId in cache.blocks) {
+                        if (Object.prototype.hasOwnProperty.call(cache.blocks, blockId)) {
+                            const blockDefinition = cache.blocks[blockId];
+                            let blockTextContent = "";
+                            try {
+                               const fileContent = await this.app.vault.cachedRead(file);
+                               const blockPosition = blockDefinition.position;
+                               // Need editor instance to convert pos to offset
+                               const editor = this.context.editor;
+                               const startOffset = editor.posToOffset(blockPosition.start);
+                               const endOffset = editor.posToOffset(blockPosition.end);
+                               blockTextContent = fileContent.substring(startOffset, endOffset);
+                            } catch (e) {
+                                console.warn("Could not read block content for recent file search:", e);
+                            }
+
+                            if (blockTextContent) {
+                                const blockMatchResult = fuzzySearch(query, blockTextContent.toLowerCase().slice(0, 256)); // Search on first 256 chars for perf
+                                if (blockMatchResult) {
+                                    recentMatches.push({
+                                        type: 'block',
+                                        displayText: blockTextContent.split('\n')[0].substring(0, 80),
+                                        insertText: `${file.basename}#^${blockId}`,
+                                        filePath: file.path,
+                                        score: blockMatchResult.score,
+                                        isRecent: true,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        recentMatches.sort((a, b) => b.score - a.score); // Sort recent matches by their own scores first
+        for (const sug of recentMatches) {
+            if (!uniqueSuggestions.has(sug.insertText) || (uniqueSuggestions.get(sug.insertText)!.score < sug.score) ) {
+                 uniqueSuggestions.set(sug.insertText, sug);
+            }
+        }
+
+        // --- Stage 2: Omnisearch (if query exists) ---
+        if (query.length > 0 && this.omnisearchApi) {
+            try {
+                const omniResults = await this.omnisearchApi.search(query);
+                for (const result of omniResults) {
+                    const file = this.app.vault.getFileByPath(result.path);
+                    if (file) {
+                        const omniSug: MySuggestion = {
+                            type: 'content', // Omnisearch results are 'content' type
+                            displayText: file.basename, // Display note title
+                            insertText: file.basename,  // Insert note title (standard link)
+                            filePath: file.path,
+                            score: result.score, // Use Omnisearch's score
+                            isRecent: this.recentFiles.some(rf => rf.path === file.path) // Mark if it's also a recent file
+                        };
+
+                        const existingSug = uniqueSuggestions.get(omniSug.insertText);
+                        if (!existingSug) {
+                            uniqueSuggestions.set(omniSug.insertText, omniSug);
+                        } else {
+                            // As per plan: "Add to uniqueSuggestions only if not already present or if Omnisearch score is higher
+                            // AND existing suggestion is not 'note' or 'alias'".
+                            // This means Omnisearch can replace a 'heading' or 'block' or another 'content' match if its score is better for the same note.
+                            // It should not replace a 'note' or 'alias' match from recents for the *same insertText*.
+                            // If existing is 'note' or 'alias', we prefer that, unless Omnisearch found it AND it's also recent AND has a higher score.
+                            // The current logic for recent files already tries to add note/alias with high scores.
+                            // If Omnisearch finds a note that was *also* a recent 'note' or 'alias', and Omnisearch gives it a *higher* score,
+                            // we might want to update. But the current structure adds recents first.
+                            // Let's refine: if Omnisearch provides a result for the *same note* (insertText)
+                            // and the existing one is from recents but only a heading/block match,
+                            // and Omnisearch has a better score, it can be replaced.
+                            // If the existing one is a note/alias from recents, it's likely preferred.
+                            // The provided rule: "if (!existingSug || (existingSug.score < omniSug.score && existingSug.type !== 'note' && existingSug.type !== 'alias'))"
+                            // This implies an Omnisearch result (type 'content') could replace a recent 'heading' or 'block' if its score is higher.
+                            // This seems reasonable.
+                            if (existingSug.type !== 'note' && existingSug.type !== 'alias') {
+                                if (omniSug.score > existingSug.score) {
+                                    uniqueSuggestions.set(omniSug.insertText, omniSug);
+                                }
+                            } else if (existingSug.type === 'content' && omniSug.score > existingSug.score) {
+                                // If existing is also content, replace if new score is higher
+                                uniqueSuggestions.set(omniSug.insertText, omniSug);
+                            }
+                        }
+                    }
+                }
+            } catch (e) {
+                console.error("Error using Omnisearch:", e);
+                // Optionally, notify the user that Omnisearch failed for this query
+                // new Notice("Omnisearch query failed.", 3000);
+            }
+        }
+
+        // Convert map to array
+        let suggestions = Array.from(uniqueSuggestions.values());
+
+        // Final sorting logic
+        suggestions.sort((a, b) => {
+            // Prioritize recent items
+            if (a.isRecent && !b.isRecent) return -1;
+            if (!a.isRecent && b.isRecent) return 1;
+
+            // If both are recent or both are not, sort by score descending
+            // Within recents, 'note' and 'alias' types might be boosted by earlier scoring.
+            // If types are different but scores are similar, this doesn't differentiate further,
+            // but the scores themselves should reflect preference (e.g. exact recent title match has high score).
+            return b.score - a.score;
+        });
+
+        return suggestions;
+    }
+
+    // --- Part 4: Rendering and Selection ---
+    renderSuggestion(suggestion: MySuggestion, el: HTMLElement): void {
+        el.empty(); // Clear any existing content
+        // As per plan: "display only the Note Title" (or alias/heading/block snippet for displayText)
+        // "Do not show the file path or indicate the type of link"
+        el.createEl('div', { text: suggestion.displayText, cls: 'enhanced-link-suggestion-text' });
+    }
+
+    selectSuggestion(suggestion: MySuggestion, event: KeyboardEvent | MouseEvent): void {
+        // this.context is provided by EditorSuggest and should be available here
+        if (!this.context || !this.context.editor) {
+            return;
+        }
+
+        this.context.editor.replaceRange(
+            `[[${suggestion.insertText}]]`, // Use the pre-formatted insertText
+            this.context.start,
+            this.context.end
+        );
+
+        // No need to close the suggester explicitly, Obsidian handles it.
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,94 +1,32 @@
-# Obsidian Sample Plugin
+# Enhanced Link Intellisense for Obsidian
 
-This is a sample plugin for Obsidian (https://obsidian.md).
+This plugin supercharges the note linking experience in Obsidian by providing more relevant and context-aware autocomplete suggestions. It focuses on recently accessed files and leverages the power of the Omnisearch plugin for comprehensive content search.
 
-This project uses TypeScript to provide type checking and documentation.
-The repo depends on the latest plugin API (obsidian.d.ts) in TypeScript Definition format, which contains TSDoc comments describing what it does.
+## !! Hard Dependency: Omnisearch Plugin !!
 
-This sample plugin demonstrates some of the basic functionality the plugin API can do.
-- Adds a ribbon icon, which shows a Notice when clicked.
-- Adds a command "Open Sample Modal" which opens a Modal.
-- Adds a plugin setting tab to the settings page.
-- Registers a global click event and output 'click' to the console.
-- Registers a global interval which logs 'setInterval' to the console.
+**This plugin WILL NOT WORK without the [Omnisearch plugin](https://github.com/scambier/obsidian-omnisearch) installed and enabled.**
 
-## First time developing plugins?
+Omnisearch is used for all content-based search suggestions. If Omnisearch is not detected, this plugin will display a notification and its core suggestion features will be disabled.
 
-Quick starting guide for new plugin devs:
+## Features
 
-- Check if [someone already developed a plugin for what you want](https://obsidian.md/plugins)! There might be an existing plugin similar enough that you can partner up with.
-- Make a copy of this repo as a template with the "Use this template" button (login to GitHub if you don't see it).
-- Clone your repo to a local development folder. For convenience, you can place this folder in your `.obsidian/plugins/your-plugin-name` folder.
-- Install NodeJS, then run `npm i` in the command line under your repo folder.
-- Run `npm run dev` to compile your plugin from `main.ts` to `main.js`.
-- Make changes to `main.ts` (or create new `.ts` files). Those changes should be automatically compiled into `main.js`.
-- Reload Obsidian to load the new version of your plugin.
-- Enable plugin in settings window.
-- For updates to the Obsidian API run `npm update` in the command line under your repo folder.
+*   **Intelligent Suggestions:** Activates when you type `[[`.
+*   **Recent Files First:**
+    *   If you haven't typed anything after `[[`, a list of your most recently accessed notes is shown.
+    *   When you start typing, recent files are filtered by title, alias, headings, and block content.
+*   **Omnisearch Integration:** Simultaneously searches your entire vault's content using Omnisearch for the typed query.
+*   **Prioritized Results:** Suggestions from recent files that match your query are generally prioritized, followed by Omnisearch content matches.
+*   **Clean Display:** Suggestions only show the note title (or alias/heading/block snippet), keeping the list clean and easy to read.
+*   **Accurate Link Insertion:** Correctly inserts links for notes, aliases, headings, or blocks.
 
-## Releasing new releases
+## How it Works
 
-- Update your `manifest.json` with your new version number, such as `1.0.1`, and the minimum Obsidian version required for your latest release.
-- Update your `versions.json` file with `"new-plugin-version": "minimum-obsidian-version"` so older versions of Obsidian can download an older version of your plugin that's compatible.
-- Create new GitHub release using your new version number as the "Tag version". Use the exact version number, don't include a prefix `v`. See here for an example: https://github.com/obsidianmd/obsidian-sample-plugin/releases
-- Upload the files `manifest.json`, `main.js`, `styles.css` as binary attachments. Note: The manifest.json file must be in two places, first the root path of your repository and also in the release.
-- Publish the release.
+When you type `[[` to create a link, this plugin:
+1.  Immediately offers suggestions from your recently opened files if your query is empty.
+2.  As you type, it filters through your recent files (matching titles, aliases, headings, and even content within blocks).
+3.  Simultaneously, it sends your query to the Omnisearch plugin to find matches in the content of any note in your vault.
+4.  It then combines and ranks these suggestions, aiming to show you the most relevant links first.
 
-> You can simplify the version bump process by running `npm version patch`, `npm version minor` or `npm version major` after updating `minAppVersion` manually in `manifest.json`.
-> The command will bump version in `manifest.json` and `package.json`, and add the entry for the new version to `versions.json`
+---
 
-## Adding your plugin to the community plugin list
-
-- Check the [plugin guidelines](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines).
-- Publish an initial version.
-- Make sure you have a `README.md` file in the root of your repo.
-- Make a pull request at https://github.com/obsidianmd/obsidian-releases to add your plugin.
-
-## How to use
-
-- Clone this repo.
-- Make sure your NodeJS is at least v16 (`node --version`).
-- `npm i` or `yarn` to install dependencies.
-- `npm run dev` to start compilation in watch mode.
-
-## Manually installing the plugin
-
-- Copy over `main.js`, `styles.css`, `manifest.json` to your vault `VaultFolder/.obsidian/plugins/your-plugin-id/`.
-
-## Improve code quality with eslint (optional)
-- [ESLint](https://eslint.org/) is a tool that analyzes your code to quickly find problems. You can run ESLint against your plugin to find common bugs and ways to improve your code. 
-- To use eslint with this project, make sure to install eslint from terminal:
-  - `npm install -g eslint`
-- To use eslint to analyze this project use this command:
-  - `eslint main.ts`
-  - eslint will then create a report with suggestions for code improvement by file and line number.
-- If your source code is in a folder, such as `src`, you can use eslint with this command to analyze all files in that folder:
-  - `eslint .\src\`
-
-## Funding URL
-
-You can include funding URLs where people who use your plugin can financially support it.
-
-The simple way is to set the `fundingUrl` field to your link in your `manifest.json` file:
-
-```json
-{
-    "fundingUrl": "https://buymeacoffee.com"
-}
-```
-
-If you have multiple URLs, you can also do:
-
-```json
-{
-    "fundingUrl": {
-        "Buy Me a Coffee": "https://buymeacoffee.com",
-        "GitHub Sponsor": "https://github.com/sponsors",
-        "Patreon": "https://www.patreon.com/"
-    }
-}
-```
-
-## API Documentation
-
-See https://github.com/obsidianmd/obsidian-api
+Developed by AI Developer with assistance from human guidance.

--- a/main.ts
+++ b/main.ts
@@ -1,134 +1,42 @@
-import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { Plugin, Notice, App } from 'obsidian';
+import { EnhancedLinkSuggester } from './EnhancedLinkSuggester'; // Assuming EnhancedLinkSuggester will be in the same directory
 
-// Remember to rename these classes and interfaces!
-
-interface MyPluginSettings {
-	mySetting: string;
+// Type declaration for Omnisearch global object
+declare global {
+    interface Window {
+        omnisearch?: {
+            search: (query: string) => Promise<{ path: string, content: string, score: number }[]>;
+            // Add other Omnisearch API methods you might use in the future
+        };
+    }
 }
 
-const DEFAULT_SETTINGS: MyPluginSettings = {
-	mySetting: 'default'
-}
+export default class EnhancedLinkPlugin extends Plugin {
+    // No need for isOmnisearchAvailable property as per the latest plan,
+    // the check is done directly in onload.
 
-export default class MyPlugin extends Plugin {
-	settings: MyPluginSettings;
+    constructor(app: App, manifest: any) {
+        super(app, manifest);
+    }
 
-	async onload() {
-		await this.loadSettings();
+    async onload() {
+        console.log('Loading Enhanced Link Plugin');
 
-		// This creates an icon in the left ribbon.
-		const ribbonIconEl = this.addRibbonIcon('dice', 'Sample Plugin', (evt: MouseEvent) => {
-			// Called when the user clicks the icon.
-			new Notice('This is a notice!');
-		});
-		// Perform additional things with the ribbon
-		ribbonIconEl.addClass('my-plugin-ribbon-class');
+        if (typeof window.omnisearch === 'undefined' || typeof window.omnisearch.search !== 'function') {
+            new Notice('Enhanced Link Suggestions: Omnisearch plugin is **required** and not found/active. This plugin will not function.', 10000); // Increased duration
+            console.error('Omnisearch plugin is required but not loaded or its search function is unavailable.');
+            // Do not register the suggester and effectively disable the plugin's core feature
+            return;
+        } else {
+            console.log('Omnisearch detected and will be used.');
+            // Pass the omnisearch API directly to the suggester
+            this.registerEditorSuggest(new EnhancedLinkSuggester(this.app, window.omnisearch));
+        }
+    }
 
-		// This adds a status bar item to the bottom of the app. Does not work on mobile apps.
-		const statusBarItemEl = this.addStatusBarItem();
-		statusBarItemEl.setText('Status Bar Text');
-
-		// This adds a simple command that can be triggered anywhere
-		this.addCommand({
-			id: 'open-sample-modal-simple',
-			name: 'Open sample modal (simple)',
-			callback: () => {
-				new SampleModal(this.app).open();
-			}
-		});
-		// This adds an editor command that can perform some operation on the current editor instance
-		this.addCommand({
-			id: 'sample-editor-command',
-			name: 'Sample editor command',
-			editorCallback: (editor: Editor, view: MarkdownView) => {
-				console.log(editor.getSelection());
-				editor.replaceSelection('Sample Editor Command');
-			}
-		});
-		// This adds a complex command that can check whether the current state of the app allows execution of the command
-		this.addCommand({
-			id: 'open-sample-modal-complex',
-			name: 'Open sample modal (complex)',
-			checkCallback: (checking: boolean) => {
-				// Conditions to check
-				const markdownView = this.app.workspace.getActiveViewOfType(MarkdownView);
-				if (markdownView) {
-					// If checking is true, we're simply "checking" if the command can be run.
-					// If checking is false, then we want to actually perform the operation.
-					if (!checking) {
-						new SampleModal(this.app).open();
-					}
-
-					// This command will only show up in Command Palette when the check function returns true
-					return true;
-				}
-			}
-		});
-
-		// This adds a settings tab so the user can configure various aspects of the plugin
-		this.addSettingTab(new SampleSettingTab(this.app, this));
-
-		// If the plugin hooks up any global DOM events (on parts of the app that doesn't belong to this plugin)
-		// Using this function will automatically remove the event listener when this plugin is disabled.
-		this.registerDomEvent(document, 'click', (evt: MouseEvent) => {
-			console.log('click', evt);
-		});
-
-		// When registering intervals, this function will automatically clear the interval when the plugin is disabled.
-		this.registerInterval(window.setInterval(() => console.log('setInterval'), 5 * 60 * 1000));
-	}
-
-	onunload() {
-
-	}
-
-	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-	}
-
-	async saveSettings() {
-		await this.saveData(this.settings);
-	}
-}
-
-class SampleModal extends Modal {
-	constructor(app: App) {
-		super(app);
-	}
-
-	onOpen() {
-		const {contentEl} = this;
-		contentEl.setText('Woah!');
-	}
-
-	onClose() {
-		const {contentEl} = this;
-		contentEl.empty();
-	}
-}
-
-class SampleSettingTab extends PluginSettingTab {
-	plugin: MyPlugin;
-
-	constructor(app: App, plugin: MyPlugin) {
-		super(app, plugin);
-		this.plugin = plugin;
-	}
-
-	display(): void {
-		const {containerEl} = this;
-
-		containerEl.empty();
-
-		new Setting(containerEl)
-			.setName('Setting #1')
-			.setDesc('It\'s a secret')
-			.addText(text => text
-				.setPlaceholder('Enter your secret')
-				.setValue(this.plugin.settings.mySetting)
-				.onChange(async (value) => {
-					this.plugin.settings.mySetting = value;
-					await this.plugin.saveSettings();
-				}));
-	}
+    onunload() {
+        console.log('Unloading Enhanced Link Plugin');
+        // Obsidian automatically handles unregistering editor suggesters.
+        // If other event listeners or resources were added, they would be cleaned up here.
+    }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,16 @@
 {
-	"id": "sample-plugin",
-	"name": "Sample Plugin",
-	"version": "1.0.0",
-	"minAppVersion": "0.15.0",
-	"description": "Demonstrates some of the capabilities of the Obsidian API.",
-	"author": "Obsidian",
-	"authorUrl": "https://obsidian.md",
-	"fundingUrl": "https://obsidian.md/pricing",
-	"isDesktopOnly": false
+    "id": "enhanced-link-intellisense",
+    "name": "Enhanced Link Intellisense",
+    "version": "1.0.0",
+    "minAppVersion": "0.15.0",
+    "description": "Provides enhanced intellisense for note links, including recent files and Omnisearch integration.",
+    "author": "AI Developer",
+    "authorUrl": "",
+    "isDesktopOnly": false,
+    "dependencies": [
+        {
+            "id": "omnisearch",
+            "version": "1.0.0"
+        }
+    ]
 }

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,37 @@
+// utils.ts
+export function debounced<T extends (...args: any[]) => any>(
+    func: T,
+    delay: number
+): (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>> {
+    let timeout: NodeJS.Timeout | null;
+    let currentResolve: ((value: Awaited<ReturnType<T>>) => void) | null;
+    let currentReject: ((reason?: any) => void) | null;
+
+    return function(this: ThisParameterType<T>, ...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> {
+        return new Promise((resolve, reject) => {
+            currentResolve = resolve;
+            currentReject = reject;
+
+            if (timeout) {
+                clearTimeout(timeout);
+            }
+
+            timeout = setTimeout(async () => {
+                timeout = null;
+                try {
+                    const result = await func.apply(this, args);
+                    if (currentResolve) {
+                        currentResolve(result);
+                    }
+                } catch (error) {
+                    if (currentReject) {
+                        currentReject(error);
+                    }
+                } finally {
+                    currentResolve = null;
+                    currentReject = null;
+                }
+            }, delay);
+        });
+    };
+}


### PR DESCRIPTION
Adds an Obsidian plugin for improved note link suggestions.

Key features:
- Activates on `[[` trigger.
- Suggests recently opened files if no query is typed.
- Filters recent files by title, alias, heading, and block content when a query is present.
- Integrates with the Omnisearch plugin for vault-wide content search.
- Prioritizes recent file matches and then Omnisearch results, sorted by relevance.
- Displays only the note title (or relevant part like alias/heading) in suggestions.
- Correctly inserts links for notes, aliases, headings, and blocks.
- Includes a debounced search function for performance.
- Requires Omnisearch plugin as a hard dependency; displays a notice and disables functionality if Omnisearch is not found.
- Adds a README file detailing functionality and the Omnisearch dependency.

The plugin consists of:
- `main.ts`: Entry point, Omnisearch check, suggester registration.
- `EnhancedLinkSuggester.ts`: Core logic for triggering, fetching, rendering, and selecting suggestions.
- `utils.ts`: Debounce utility function.
- `manifest.json`: Plugin metadata and Omnisearch dependency.
- `README.md`: User documentation.